### PR TITLE
Adding initial commit of CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# This should match the team set up in https://github.com/orgs/opensearch-project/teams and include any additional contributors
+*   @opensearch-project/clients @Yury-Fridlyand


### PR DESCRIPTION
Signed-off-by: CEHENKLE <henkle@amazon.com>

Description
Add support for codeowners to repo

For more details, see [Meta issue](https://github.com/opensearch-project/project-meta/issues/31)

Check List
 Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
