### PR TITLE
Remove links to Elastic artifacts API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,9 +28,6 @@ jobs:
     - uses: actions/setup-dotnet@v1
       with:
         dotnet-version: '5.0.100'
-        source-url: https://nuget.pkg.github.com/elastic/index.json
-      env:
-        NUGET_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
         
     - run: ./build.sh build -s true
       name: Build
@@ -40,29 +37,3 @@ jobs:
       with:
         name: nuget-packages
         path: build/output/*
-    # - run: ./build.sh validatepackages -s true
-    #   name: "validate *.npkg files that were created"
-    # - run: ./build.sh generateapichanges -s true
-    #   name: "Inspect public API changes"
-
-    # - name: publish canary packages github package repository
-    #   if: github.event_name == 'push' && startswith(github.ref, 'refs/heads')
-    #   shell: bash
-    #   run:  |
-    #       until dotnet nuget push 'build/output/*.nupkg' -k ${{secrets.GITHUB_TOKEN}} --skip-duplicate --no-symbols true; do echo "Retrying"; sleep 1; done;
-
-    # # Github packages requires authentication, this is likely going away in the future so for now we publish to feedz.io
-    # - run: dotnet nuget push 'build/output/*.nupkg' -k ${{secrets.FEEDZ_IO_API_KEY}} -s https://f.feedz.io/elastic/all/nuget/index.json --skip-duplicate --no-symbols true
-    #   name: publish canary packages to feedz.io
-    #   if: github.event_name == 'push' && startswith(github.ref, 'refs/heads')
-
-    # - run: ./build.sh generatereleasenotes -s true
-    #   name: Generate release notes for tag
-    #   if: github.event_name == 'push' && startswith(github.ref, 'refs/tags')
-    # - run: ./build.sh createreleaseongithub -s true --token ${{secrets.GITHUB_TOKEN}}
-    #   if: github.event_name == 'push' && startswith(github.ref, 'refs/tags')
-    #   name: Create or update release for tag on github
-          
-    # - run: dotnet nuget push 'build/output/*.nupkg' -k ${{secrets.NUGET_ORG_API_KEY}} -s https://api.nuget.org/v3/index.json --skip-duplicate --no-symbols true
-    #   name: release to nuget.org
-    #   if: github.event_name == 'push' && startswith(github.ref, 'refs/tags')

--- a/src/OpenSearch.Stack.ArtifactsApi/README.md
+++ b/src/OpenSearch.Stack.ArtifactsApi/README.md
@@ -13,7 +13,7 @@ Supports:
     * `commit_hash:version` a build candidate for a version
 
 3. Released versions
-    * `MAJOR.MINOR.PATH` where `MAJOR` is still supported as defined by the EOL policy of Elastic.
+    * `MAJOR.MINOR.PATH` where `MAJOR` is still supported as defined by the EOL policy of OpenSearch.
     * Note if the version exists but is not yet released it will resolve as a build candidate
     
 

--- a/src/OpenSearch.Stack.ArtifactsApi/Resolvers/ApiResolver.cs
+++ b/src/OpenSearch.Stack.ArtifactsApi/Resolvers/ApiResolver.cs
@@ -41,7 +41,7 @@ namespace OpenSearch.Stack.ArtifactsApi.Resolvers
 	public static class ApiResolver
 	{
 		// TODO: update string when working on artifacts API
-		private const string ArtifactsApiUrl = "https://artifacts-api.elastic.co/v1/";
+		private const string ArtifactsApiUrl = "https://artifacts-api.opensearch.org/v1/";
 
 		private static readonly ConcurrentDictionary<string, bool> Releases = new ConcurrentDictionary<string, bool>();
 
@@ -53,7 +53,7 @@ namespace OpenSearch.Stack.ArtifactsApi.Resolvers
 
 		private static Regex BuildHashRegex { get; } =
 			// TODO: update string when working on artifacts API
-			new Regex(@"https://(?:snapshots|staging).elastic.co/(\d+\.\d+\.\d+-([^/]+)?)");
+			new Regex(@"https://(?:snapshots|staging).opensearch.org/(\d+\.\d+\.\d+-([^/]+)?)");
 
 		public static string FetchJson(string path)
 		{

--- a/src/OpenSearch.Stack.ArtifactsApi/Resolvers/ReleasedVersionResolver.cs
+++ b/src/OpenSearch.Stack.ArtifactsApi/Resolvers/ReleasedVersionResolver.cs
@@ -34,8 +34,7 @@ namespace OpenSearch.Stack.ArtifactsApi.Resolvers
 {
 	public static class ReleasedVersionResolver
 	{
-		//https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-7.1.0-linux-x86_64.tar.gz
-		private const string ArtifactsUrl = "https://artifacts.elastic.co";
+		private const string ArtifactsUrl = "https://artifacts.opensearch.org";
 
 		public static bool TryResolve(Product product, Version version, OSPlatform os, out Artifact artifact)
 		{

--- a/src/OpenSearch.Stack.ArtifactsApi/Resolvers/SnapshotApiResolver.cs
+++ b/src/OpenSearch.Stack.ArtifactsApi/Resolvers/SnapshotApiResolver.cs
@@ -94,7 +94,6 @@ namespace OpenSearch.Stack.ArtifactsApi.Resolvers
 
 				if (!tokens[0].Equals(p, StringComparison.CurrentCultureIgnoreCase)) continue;
 				if (!tokens[1].Equals(version.ToString(), StringComparison.CurrentCultureIgnoreCase)) continue;
-				// https://snapshots.elastic.co/7.4.0-677857dd/downloads/elasticsearch-plugins/analysis-icu/analysis-icu-7.4.0-SNAPSHOT.zip
 				var buildHash = ApiResolver.GetBuildHash(kv.Value.DownloadUrl);
 				artifact = new Artifact(product, version, kv.Value, buildHash);
 			}

--- a/src/OpenSearch.Stack.ArtifactsApi/Resolvers/StagingVersionResolver.cs
+++ b/src/OpenSearch.Stack.ArtifactsApi/Resolvers/StagingVersionResolver.cs
@@ -34,10 +34,8 @@ namespace OpenSearch.Stack.ArtifactsApi.Resolvers
 	public static class StagingVersionResolver
 	{
 		// TODO: update string when working on artifacts API
-		private const string StagingUrlFormat = "https://staging.elastic.co/{0}-{1}";
+		private const string StagingUrlFormat = "https://staging.opensearch.org/{0}-{1}";
 
-		// https://staging.elastic.co/7.2.0-957e3089/downloads/elasticsearch/elasticsearch-7.2.0-linux-x86_64.tar.gz
-		// https://staging.elastic.co/7.2.0-957e3089/downloads/elasticsearch-plugins/analysis-icu/analysis-icu-7.2.0.zip
 		public static bool TryResolve(Product product, Version version, string buildHash, out Artifact artifact)
 		{
 			artifact = null;


### PR DESCRIPTION
Signed-off-by: Yury Fridlyand <yuryf@bitquilltech.com>

### Description
Removed/replaced links that refer to Elastic artifact API
 
### Issues Resolved
N/A
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
