### PR TITLE
Publish opensearch-net-abstractions NuGet packages to GitHub NuGet repository

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,5 @@
-name: Always be deploying
-
+name: Build and publish snapshot packages
 on:
-  pull_request:
-    paths-ignore: 
-      - 'README.md'
-      - '.editorconfig'
   push:
     paths-ignore:
       - 'README.md'
@@ -28,12 +23,41 @@ jobs:
     - uses: actions/setup-dotnet@v1
       with:
         dotnet-version: '5.0.100'
-        
+  
     - run: ./build.sh build -s true
       name: Build
+
     - run: ./build.sh generatepackages -s true
       name: Generate local nuget packages
+
     - uses: actions/upload-artifact@v2
       with:
         name: nuget-packages
         path: build/output/*
+
+    - run: ./build.sh validatepackages -s true
+      name: Validate *.npkg files that were created
+
+    - name: Publish packages to GitHub package repository
+      if: github.event_name == 'push' && startswith(github.ref, 'refs/heads/main')
+      shell: bash
+      run:  |
+         OWNER=$GITHUB_REPOSITORY_OWNER
+         NUGET_REPO="https://nuget.pkg.github.com/$OWNER/index.json"
+         dotnet nuget add source --username $OWNER --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text --name github "$NUGET_REPO"  
+         dotnet nuget push 'build/output/*.nupkg' -s github -k ${{secrets.GITHUB_TOKEN}} --skip-duplicate --no-symbols true
+  
+  delete-stale-pre-release-packages:
+    runs-on: ubuntu-18.04
+    needs: build
+    if: github.event_name == 'push' && startswith(github.ref, 'refs/heads/main')
+    strategy:
+      matrix:
+        # Is this list the same as the nuget packages generated in opensearch-net-abstractions repo?
+        package: [OpenSearch.OpenSearch.Ephemeral, OpenSearch.OpenSearch.Managed, OpenSearch.OpenSearch.Xunit, OpenSearch.Stack.ArtifactsApi]
+    steps:
+    - uses: actions/delete-package-versions@v3
+      with: 
+        package-name: ${{ matrix.package }}
+        min-versions-to-keep: 1
+        delete-only-pre-release-versions: "true"

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@
 
 You've reached the home repository for several auxiliary projects from the .NET team within OpenSearch.
 
+Pre-release packages of these projects are available at [OpenSearch NuGet Package Repository](https://www.github.com/opensearch-project/packages). See [GitHub documentation](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-nuget-registry#installing-a-package) for instructions on how to access them.
+
 Current projects:
 
 ### [OpenSearch.OpenSearch.Managed](src/OpenSearch.OpenSearch.Managed/README.md)

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -6,6 +6,7 @@
     <Copyright>OpenSearch</Copyright>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <RepositoryUrl>https://github.com/opensearch-project/opensearch-net-abstractions</RepositoryUrl>
+    <RepositoryType>Git</RepositoryType>
     <PackageProjectUrl>https://github.com/opensearch-project/opensearch-net-abstractions</PackageProjectUrl>
     <PackageReleaseNotes>https://github.com/opensearch-project/opensearch-net-abstractions/releases</PackageReleaseNotes>
 


### PR DESCRIPTION
### Description

This PR updates `.github/workflows/ci.yml` to publish generated NuGet packages to the opensearch-project NuGet package repository. 

It also adds a job to the ci workflow to delete all but the most recent NuGet packages. 
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
