### PR TITLE
Added installation path for plugins

### DIFF
--- a/src/OpenSearch.OpenSearch.Ephemeral/Tasks/InstallationTasks/InstallPlugins.cs
+++ b/src/OpenSearch.OpenSearch.Ephemeral/Tasks/InstallationTasks/InstallPlugins.cs
@@ -93,10 +93,21 @@ namespace OpenSearch.OpenSearch.Ephemeral.Tasks.InstallationTasks
 					cluster.Writer,
 					fs.PluginBinary,
 					$"install opensearch plugin: {plugin.SubProductName}",
-					"install --batch", plugin.SubProductName);
+					"install --batch", GetPluginLocation(plugin, v));
 
 				CopyConfigDirectoryToHomeCacheConfigDirectory(cluster, plugin);
 			}
+		}
+
+		private static string GetPluginLocation(OpenSearchPlugin plugin, OpenSearchVersion v)
+		{
+			// OpenSearch 1.0.0 artifacts were not published. The plugins are built in the workflow and used here.
+			if (v == "1.0.0")
+				// The environment variable is set in the integration workflow in
+				// https://github.com/opensearch-project/opensearch-net/blob/main/.github/workflows/integration.yml
+				return "file://" + Environment.GetEnvironmentVariable("plugins-directory") + $"/{plugin.SubProductName}-{v}.zip";
+			else
+				return plugin.SubProductName;
 		}
 
 		private static void CopyConfigDirectoryToHomeCacheConfigDirectory(


### PR DESCRIPTION
Signed-off-by: Guian Gumpac <guiang@bitquilltech.com>

### Description
Due to plugins not being published for [OpenSearch 1.0.0](https://github.com/opensearch-project/project-website/issues/737#issuecomment-1077805006), we had to build the plugins in the workflow and install with abstractions. This change will use the plugins built and stored in the specified environment variable by the workflow.
  
### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
