### PR TITLE
Support OpenSearch 2.0

### DIFF
--- a/src/OpenSearch.OpenSearch.Ephemeral/Tasks/InstallationTasks/InitialConfiguration.cs
+++ b/src/OpenSearch.OpenSearch.Ephemeral/Tasks/InstallationTasks/InitialConfiguration.cs
@@ -48,7 +48,7 @@ namespace OpenSearch.OpenSearch.Ephemeral.Tasks.InstallationTasks
 			var script = Path.Combine(fs.OpenSearchHome, "server-initial-config.sh");
 
 			if (cluster.ClusterConfiguration.Artifact.ServerType == ServerType.OpenSearch)
-				File.WriteAllText(script, InitialConfigurationOpenSearch.GetConfigurationScript());
+				File.WriteAllText(script, InitialConfigurationOpenSearch.GetConfigurationScript(cluster.ClusterConfiguration.Version));
 			if (cluster.ClusterConfiguration.Artifact.ServerType == ServerType.OpenDistro)
 				File.WriteAllText(script, InitialConfigurationOpenDistro.GetConfigurationScript());
 

--- a/src/OpenSearch.OpenSearch.Ephemeral/Tasks/InstallationTasks/InitialConfigurationOpenSearch.cs
+++ b/src/OpenSearch.OpenSearch.Ephemeral/Tasks/InstallationTasks/InitialConfigurationOpenSearch.cs
@@ -25,6 +25,8 @@
 *  under the License.
 */
 
+using OpenSearch.Stack.ArtifactsApi;
+
 namespace OpenSearch.OpenSearch.Ephemeral.Tasks.InstallationTasks
 {
 	internal class InitialConfigurationOpenSearch
@@ -35,7 +37,10 @@ namespace OpenSearch.OpenSearch.Ephemeral.Tasks.InstallationTasks
 		// the server what we want to do on our own, it is decided to have a
 		// snapshot of this file.
 		// The script is taken from v.1.2.4, last 3 lines omitted.
-		public static string GetConfigurationScript() =>
+		public static string GetConfigurationScript(OpenSearchVersion version)
+		{
+			if (version < (OpenSearchVersion)"2.0.0")
+				return
 @"#!/bin/bash
 
 # Copyright OpenSearch Contributors
@@ -51,8 +56,8 @@ chmod 755 $OPENSEARCH_HOME/plugins/opensearch-performance-analyzer/pa_bin/perfor
 chmod 755 $OPENSEARCH_HOME/bin/performance-analyzer-agent-cli
 echo ""done security""
 PA_AGENT_JAVA_OPTS=""-Dlog4j.configurationFile=$OPENSEARCH_HOME/plugins/opensearch-performance-analyzer/pa_config/log4j2.xml \
-              -Xms64M -Xmx64M -XX:+UseSerialGC -XX:CICompilerCount=1 -XX:-TieredCompilation -XX:InitialCodeCacheSize=4096 \
-              -XX:InitialBootClassLoaderMetaspaceSize=30720 -XX:MaxRAM=400m""
+			  -Xms64M -Xmx64M -XX:+UseSerialGC -XX:CICompilerCount=1 -XX:-TieredCompilation -XX:InitialCodeCacheSize=4096 \
+			  -XX:InitialBootClassLoaderMetaspaceSize=30720 -XX:MaxRAM=400m""
 
 OPENSEARCH_MAIN_CLASS=""org.opensearch.performanceanalyzer.PerformanceAnalyzerApp"" \
 OPENSEARCH_ADDITIONAL_CLASSPATH_DIRECTORIES=plugins/opensearch-performance-analyzer \
@@ -70,20 +75,73 @@ echo ""done plugins""
 
 ##Set KNN Dylib Path for macOS and *nix systems
 if echo ""$OSTYPE"" | grep -qi ""darwin""; then
-    if echo ""$JAVA_LIBRARY_PATH"" | grep -q ""$KNN_LIB_DIR""; then
-        echo ""k-NN libraries found in JAVA_LIBRARY_PATH""
-    else
-        export JAVA_LIBRARY_PATH=$JAVA_LIBRARY_PATH:$KNN_LIB_DIR
-        echo ""k-NN libraries not found in JAVA_LIBRARY_PATH. Updating path to: $JAVA_LIBRARY_PATH.""
-    fi
+	if echo ""$JAVA_LIBRARY_PATH"" | grep -q ""$KNN_LIB_DIR""; then
+		echo ""k-NN libraries found in JAVA_LIBRARY_PATH""
+	else
+		export JAVA_LIBRARY_PATH=$JAVA_LIBRARY_PATH:$KNN_LIB_DIR
+		echo ""k-NN libraries not found in JAVA_LIBRARY_PATH. Updating path to: $JAVA_LIBRARY_PATH.""
+	fi
 else
-    if echo ""$LD_LIBRARY_PATH"" | grep -q ""$KNN_LIB_DIR""; then
-        echo ""k-NN libraries found in LD_LIBRARY_PATH""
-    else
-        export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$KNN_LIB_DIR
-        echo ""k-NN libraries not found in LD_LIBRARY_PATH. Updating path to: $LD_LIBRARY_PATH.""
-    fi
+	if echo ""$LD_LIBRARY_PATH"" | grep -q ""$KNN_LIB_DIR""; then
+		echo ""k-NN libraries found in LD_LIBRARY_PATH""
+	else
+		export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$KNN_LIB_DIR
+		echo ""k-NN libraries not found in LD_LIBRARY_PATH. Updating path to: $LD_LIBRARY_PATH.""
+	fi
 fi
 ";
+			return
+	//script from 2.0.0
+	@"#!/bin/bash
+
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+export OPENSEARCH_HOME=`dirname $(realpath $0)`
+export OPENSEARCH_PATH_CONF=$OPENSEARCH_HOME/config
+cd $OPENSEARCH_HOME
+
+KNN_LIB_DIR=$OPENSEARCH_HOME/plugins/opensearch-knn/lib
+##Security Plugin
+bash $OPENSEARCH_HOME/plugins/opensearch-security/tools/install_demo_configuration.sh -y -i -s
+
+echo ""done security""
+PA_AGENT_JAVA_OPTS=""-Dlog4j.configurationFile=$OPENSEARCH_PATH_CONF/opensearch-performance-analyzer/log4j2.xml \
+			  -Xms64M -Xmx64M -XX:+UseSerialGC -XX:CICompilerCount=1 -XX:-TieredCompilation -XX:InitialCodeCacheSize=4096 \
+			  -XX:MaxRAM=400m""
+
+OPENSEARCH_MAIN_CLASS=""org.opensearch.performanceanalyzer.PerformanceAnalyzerApp"" \
+OPENSEARCH_ADDITIONAL_CLASSPATH_DIRECTORIES=plugins/opensearch-performance-analyzer \
+OPENSEARCH_JAVA_OPTS=$PA_AGENT_JAVA_OPTS
+
+if ! grep -q '## OpenSearch Performance Analyzer' $OPENSEARCH_PATH_CONF/jvm.options; then
+   CLK_TCK=`/usr/bin/getconf CLK_TCK`
+   echo >> $OPENSEARCH_PATH_CONF/jvm.options
+   echo '## OpenSearch Performance Analyzer' >> $OPENSEARCH_PATH_CONF/jvm.options
+   echo ""-Dclk.tck=$CLK_TCK"" >> $OPENSEARCH_PATH_CONF/jvm.options
+   echo ""-Djdk.attach.allowAttachSelf=true"" >> $OPENSEARCH_PATH_CONF/jvm.options
+   echo ""-Djava.security.policy=$OPENSEARCH_PATH_CONF/opensearch-performance-analyzer/opensearch_security.policy"" >> $OPENSEARCH_PATH_CONF/jvm.options
+   echo ""--add-opens=jdk.attach/sun.tools.attach=ALL-UNNAMED"" >> $OPENSEARCH_PATH_CONF/jvm.options
+fi
+echo ""done plugins""
+
+##Set KNN Dylib Path for macOS and *nix systems
+if echo ""$OSTYPE"" | grep -qi ""darwin""; then
+	if echo ""$JAVA_LIBRARY_PATH"" | grep -q ""$KNN_LIB_DIR""; then
+		echo ""k-NN libraries found in JAVA_LIBRARY_PATH""
+	else
+		export JAVA_LIBRARY_PATH=$JAVA_LIBRARY_PATH:$KNN_LIB_DIR
+		echo ""k-NN libraries not found in JAVA_LIBRARY_PATH. Updating path to: $JAVA_LIBRARY_PATH."" 
+	fi
+else
+	if echo ""$LD_LIBRARY_PATH"" | grep -q ""$KNN_LIB_DIR""; then
+		echo ""k-NN libraries found in LD_LIBRARY_PATH""
+	else
+		export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$KNN_LIB_DIR
+		echo ""k-NN libraries not found in LD_LIBRARY_PATH. Updating path to: $LD_LIBRARY_PATH.""
+	fi
+fi
+";
+		}
 	}
 }

--- a/src/OpenSearch.OpenSearch.Managed/ConsoleWriters/LineOutParser.cs
+++ b/src/OpenSearch.OpenSearch.Managed/ConsoleWriters/LineOutParser.cs
@@ -117,7 +117,6 @@ namespace OpenSearch.OpenSearch.Managed.ConsoleWriters
 			return true;
 		}
 
-
 		private bool TryGetStartedConfirmation(string section, string message)
 		{
 


### PR DESCRIPTION
Signed-off-by: Yury Fridlyand <yuryf@bitquilltech.com>

### Description
Abstractions is responsible for downloading, unpacking and installation of OpenSearch. OpenSearch's tarball has `opensearch-tar-install.sh` script which is entry point to run the server. This script configures the server and runs it - this doesn't work for us. We have to store the modified script which does configuration, but doesn't launch the cluster.
The stored script was copied from version 1.something, but it is incompatible with 2.x. The goal of this PR to add script from 2.0 release and ensure that it is executed for the corresponding version.

Sorry for unintended whitespace changes, added by IDE.

### Issues Resolved
Support OpenSearch 2.0 in integration tets.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
