### PR TITLE
Fix cluster node started check

### DIFF
--- a/src/OpenSearch.OpenSearch.Managed/ConsoleWriters/LineOutParser.cs
+++ b/src/OpenSearch.OpenSearch.Managed/ConsoleWriters/LineOutParser.cs
@@ -119,9 +119,7 @@ namespace OpenSearch.OpenSearch.Managed.ConsoleWriters
 
 		private bool TryGetStartedConfirmation(string section, string message)
 		{
-
-			var inNodeSection = _securityPluginRegex.IsMatch(section);
-			return inNodeSection && message == "Node started";
+			return section == ShortName("n.Node") && message == "started";
 		}
 
 		public bool TryGetPortNumber(string section, string message, out int port)


### PR DESCRIPTION
Signed-off-by: Yury-Fridlyand <yuryf@bitquilltech.com>

Abstractions runs OpenSearch and track the health and status of the each cluster node by reading `stdout`/`stderr`. Being subscribed to the wrong lines the library decided that node didn't start while it is actually started.

### Description
Fix validation for OpenSearch node start.

### Issues Resolved
Integration test failure on some versions (1.3.x with security).
I predict also failures with security plugin deactivated or uninstalled.


### Test results
These changes were tried in https://github.com/Bit-Quill/opensearch-net/commit/5a70962e4fe5f3e1191cbc7797cc9f3e2d9801f5
Tests (before and after fix): https://github.com/Bit-Quill/opensearch-net/actions?query=branch%3Adev-os-2.0-integ-abstractions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
